### PR TITLE
tls: use configurable TCP idle timeout

### DIFF
--- a/src/combo/dtls_turn.c
+++ b/src/combo/dtls_turn.c
@@ -301,7 +301,8 @@ static int agent_alloc(struct agent **agp, uint16_t lport,
 	/* allocate DTLS */
 	ag->dtls_active = dtls_active;
 
-	err = tls_alloc(&ag->tls, TLS_METHOD_DTLSV1, NULL, NULL);
+	err = tls_alloc(&ag->tls, TLS_METHOD_DTLSV1, TCP_IDLE_TIMEOUT,
+		NULL, NULL);
 	if (err)
 		goto out;
 
@@ -392,7 +393,8 @@ static bool have_dtls_support(enum tls_method method)
 	struct tls *tls = NULL;
 	int err;
 
-	err = tls_alloc(&tls, method, NULL, NULL);
+	err = tls_alloc(&tls, method, TCP_IDLE_TIMEOUT,
+		NULL, NULL);
 
 	mem_deref(tls);
 

--- a/src/dtls.c
+++ b/src/dtls.c
@@ -206,7 +206,8 @@ static int test_dtls_srtp_base(enum tls_method method, bool dtls_srtp)
 
 	test.dtls_srtp = dtls_srtp;
 
-	err = tls_alloc(&test.tls, method, NULL, NULL);
+	err = tls_alloc(&test.tls, method, TCP_IDLE_TIMEOUT,
+		NULL, NULL);
 	if (err)
 		goto out;
 
@@ -304,7 +305,8 @@ static bool have_dtls_support(enum tls_method method)
 	struct tls *tls = NULL;
 	int err;
 
-	err = tls_alloc(&tls, method, NULL, NULL);
+	err = tls_alloc(&tls, method, TCP_IDLE_TIMEOUT,
+		NULL, NULL);
 
 	mem_deref(tls);
 

--- a/src/mock/sipsrv.c
+++ b/src/mock/sipsrv.c
@@ -89,7 +89,8 @@ int sip_server_alloc(struct sip_server **srvp)
 		goto out;
 
 #ifdef USE_TLS
-	err = tls_alloc(&tls, TLS_METHOD_SSLV23, NULL, NULL);
+	err = tls_alloc(&tls, TLS_METHOD_SSLV23, TCP_IDLE_TIMEOUT,
+		NULL, NULL);
 	if (err)
 		goto out;
 

--- a/src/rtmp.c
+++ b/src/rtmp.c
@@ -676,7 +676,7 @@ static struct rtmp_endpoint *rtmp_endpoint_alloc(enum mode mode,
 		re_snprintf(path, sizeof(path), "%s/server-ecdsa.pem",
 			    test_datapath());
 
-		err = tls_alloc(&ep->tls, TLS_METHOD_SSLV23,
+		err = tls_alloc(&ep->tls, TLS_METHOD_SSLV23, TCP_IDLE_TIMEOUT,
 				is_client ? NULL : path, NULL);
 		if (err)
 			goto out;

--- a/src/sipreg.c
+++ b/src/sipreg.c
@@ -55,7 +55,8 @@ static int sipstack_fixture(struct sip **sipp)
 
 #ifdef USE_TLS
 	/* TLS-context for client -- no certificate needed */
-	err = tls_alloc(&tls, TLS_METHOD_SSLV23, NULL, NULL);
+	err = tls_alloc(&tls, TLS_METHOD_SSLV23, TCP_IDLE_TIMEOUT,
+		NULL, NULL);
 	if (err)
 		goto out;
 

--- a/src/tls.c
+++ b/src/tls.c
@@ -205,7 +205,8 @@ static int test_tls_base(enum tls_keytype keytype, bool add_ca, int exp_verr)
 	if (err)
 		goto out;
 
-	err = tls_alloc(&tt.tls, TLS_METHOD_SSLV23, NULL, NULL);
+	err = tls_alloc(&tt.tls, TLS_METHOD_SSLV23, TCP_IDLE_TIMEOUT,
+		NULL, NULL);
 	if (err)
 		goto out;
 
@@ -325,7 +326,8 @@ int test_tls_selfsigned(void)
 	uint8_t fp[20];
 	int err;
 
-	err = tls_alloc(&tls, TLS_METHOD_SSLV23, NULL, NULL);
+	err = tls_alloc(&tls, TLS_METHOD_SSLV23, TCP_IDLE_TIMEOUT,
+		NULL, NULL);
 	if (err)
 		goto out;
 
@@ -351,7 +353,8 @@ int test_tls_certificate(void)
 	uint8_t fp[20];
 	int err;
 
-	err = tls_alloc(&tls, TLS_METHOD_SSLV23, NULL, NULL);
+	err = tls_alloc(&tls, TLS_METHOD_SSLV23, TCP_IDLE_TIMEOUT,
+		NULL, NULL);
 	if (err)
 		goto out;
 


### PR DESCRIPTION
The idle timeout of the TCP connection can be changed
by the user if needed.