### PR TITLE
http: add test_http_request

### DIFF
--- a/src/test.c
+++ b/src/test.c
@@ -85,6 +85,7 @@ static const struct test tests[] = {
 #endif
 	TEST(test_httpauth_chall),
 	TEST(test_httpauth_resp),
+	TEST(test_http_request),
 	TEST(test_ice_cand),
 	TEST(test_ice_loop),
 	TEST(test_jbuf),

--- a/src/test.h
+++ b/src/test.h
@@ -149,6 +149,7 @@ int test_https_loop(void);
 #endif
 int test_httpauth_chall(void);
 int test_httpauth_resp(void);
+int test_http_request(void);
 int test_ice_loop(void);
 int test_ice_cand(void);
 int test_jbuf(void);


### PR DESCRIPTION
Adds a test for HTTP request. Useful also as example for https://github.com/baresip/re/pull/33.

Will build as soon as https://github.com/baresip/re/pull/33 is merged.