### PR TITLE
Adaptive jbuf

### DIFF
--- a/src/jbuf.c
+++ b/src/jbuf.c
@@ -152,60 +152,53 @@ int test_jbuf_adaptive(void)
 	memset(&hdr2, 0, sizeof(hdr2));
 	hdr.ssrc = 1;
 
-	err  = jbuf_alloc(&jb, 1, 10);
-	err |= jbuf_set_type(jb, JBUF_ADAPTIVE);
-	err |= jbuf_set_wish(jb, 2);
-	if (err)
-		return err;
+	err = jbuf_alloc(&jb, 1, 10);
+	TEST_ERR(err);
+	err = jbuf_set_type(jb, JBUF_ADAPTIVE);
+	TEST_ERR(err);
+	err = jbuf_set_wish(jb, 2);
+	TEST_ERR(err);
 
 	for (i=0; i<ARRAY_SIZE(frv); i++) {
 		frv[i] = mem_zalloc(32, NULL);
-		if (!frv[i]) {
-			err = ENOMEM;
-			goto out;
-		}
+		TEST_NOT_EQUALS(NULL, frv[i]);
 	}
 
 	/* Empty list */
 	DEBUG_INFO("test frame: Empty list\n");
-	if (ENOENT != jbuf_get(jb, &hdr2, &mem)) {
-		err = EINVAL;
-		goto out;
-	}
-
+	TEST_EQUALS(ENOENT, jbuf_get(jb, &hdr2, &mem));
 
 	/* Two frames */
 	DEBUG_INFO("test frame: Two frames\n");
 	hdr.seq = 160;
 	err = jbuf_put(jb, &hdr, frv[0]);
-	if (err)
-		goto out;
-	if ((EALREADY != jbuf_put(jb, &hdr, frv[0]))) {err = EINVAL; goto out;}
+	TEST_ERR(err);
+	TEST_EQUALS(EALREADY, jbuf_put(jb, &hdr, frv[0]));
 
 	/* wish size is not reached yet */
-	if (ENOENT != jbuf_get(jb, &hdr2, &mem)) {err = EINVAL; goto out;}
+	TEST_EQUALS(ENOENT, jbuf_get(jb, &hdr2, &mem));
 
 	hdr.seq = 161;
 	hdr.ts = 20 * 8;
 	sys_msleep(20);
 	err = jbuf_put(jb, &hdr, frv[1]);
-	if (err)
-		goto out;
+	TEST_ERR(err);
 
 	/* wish size reached */
 	err = jbuf_get(jb, &hdr2, &mem);
-	if (err)
-		goto out;
-
-	if (160 != hdr2.seq) {err = EINVAL; goto out;}
-	if (mem != frv[0]) {err = EINVAL; goto out;}
+	TEST_ERR(err);
+	TEST_EQUALS(160, hdr2.seq);
+	TEST_EQUALS(mem, frv[0]);
 	mem = mem_deref(mem);
 
-	if ((err = jbuf_get(jb, &hdr2, &mem)) || (161 != hdr2.seq)) {
-		err = err ? err : EINVAL; goto out; }
+	err = jbuf_get(jb, &hdr2, &mem);
+	TEST_ERR(err);
+	TEST_EQUALS(161, hdr2.seq);
+	TEST_EQUALS(mem, frv[1]);
 	mem = mem_deref(mem);
 
-	if (ENOENT != jbuf_get(jb, &hdr2, &mem)) {err = EINVAL; goto out;}
+	err = jbuf_get(jb, &hdr2, &mem);
+	TEST_EQUALS(ENOENT, err);
 	mem = mem_deref(mem);
 
 	/* Four  frames */
@@ -214,57 +207,54 @@ int test_jbuf_adaptive(void)
 	hdr.ts += 20 * 8;
 	sys_msleep(20);
 	err = jbuf_put(jb, &hdr, frv[0]);
-	if (err)
-		goto out;
+	TEST_ERR(err);
+
 	hdr.seq = 480;
 	hdr.ts += 20 * 8;
 	sys_msleep(20);
 	err = jbuf_put(jb, &hdr, frv[1]);
-	if (err)
-		goto out;
+	TEST_ERR(err);
+
 	hdr.seq = 490;
 	hdr.ts += 20 * 8;
 	sys_msleep(20);
 	err = jbuf_put(jb, &hdr, frv[2]);
-	if (err)
-		goto out;
+	TEST_ERR(err);
+
 	hdr.seq = 491;
 	hdr.ts += 20 * 8;
 	sys_msleep(20);
 	err = jbuf_put(jb, &hdr, frv[3]);
-	if (err)
-		goto out;
+	TEST_ERR(err);
 
 	err = jbuf_get(jb, &hdr2, &mem);
-	if (err)
-		goto out;
-	if (320 != hdr2.seq) {err = EINVAL; goto out;}
-	if (mem != frv[0]) {err = EINVAL; goto out;}
+	TEST_ERR(err);
+	TEST_EQUALS(320, hdr2.seq);
+	TEST_EQUALS(mem, frv[0]);
 	mem = mem_deref(mem);
 
 	err = jbuf_get(jb, &hdr2, &mem);
-	if (err)
-		goto out;
-	if (480 != hdr2.seq) {err = EINVAL; goto out;}
-	if (mem != frv[1]) {err = EINVAL; goto out;}
+	TEST_ERR(err);
+	TEST_EQUALS(480, hdr2.seq);
+	TEST_EQUALS(mem, frv[1]);
 	mem = mem_deref(mem);
 
 	err = jbuf_get(jb, &hdr2, &mem);
-	if (err)
-		goto out;
-	if (490 != hdr2.seq) {err = EINVAL; goto out;}
-	if (mem != frv[2]) {err = EINVAL; goto out;}
+	TEST_ERR(err);
+	TEST_EQUALS(490, hdr2.seq);
+	TEST_EQUALS(mem, frv[2]);
 	mem = mem_deref(mem);
 
 	err = jbuf_get(jb, &hdr2, &mem);
-	if (err)
-		goto out;
-	if (491 != hdr2.seq) {err = EINVAL; goto out;}
-	if (mem != frv[3]) {err = EINVAL; goto out;}
+	TEST_ERR(err);
+	TEST_EQUALS(491, hdr2.seq);
+	TEST_EQUALS(mem, frv[3]);
 	mem = mem_deref(mem);
 
-	if (ENOENT != jbuf_get(jb, &hdr2, &mem)) {err = EINVAL; goto out;}
+	err = jbuf_get(jb, &hdr2, &mem);
+	TEST_EQUALS(ENOENT, err);
 	mem = mem_deref(mem);
+	err = 0;
 
  out:
 	mem_deref(jb);

--- a/src/jbuf.c
+++ b/src/jbuf.c
@@ -12,7 +12,6 @@
 #define DEBUG_LEVEL 5
 #include <re_dbg.h>
 
-
 int test_jbuf(void)
 {
 	struct rtp_header hdr, hdr2;
@@ -128,6 +127,144 @@ int test_jbuf(void)
 
 	if (ENOENT != jbuf_get(jb, &hdr2, &mem)) {err = EINVAL; goto out;}
 
+
+ out:
+	mem_deref(jb);
+	mem_deref(mem);
+	for (i=0; i<ARRAY_SIZE(frv); i++)
+		mem_deref(frv[i]);
+
+	return err;
+}
+
+
+int test_jbuf_adaptive(void)
+{
+	struct rtp_header hdr, hdr2;
+	struct jbuf *jb = NULL;
+	char *frv[4];
+	uint32_t i;
+	void *mem = NULL;
+	int err;
+
+	memset(frv, 0, sizeof(frv));
+	memset(&hdr, 0, sizeof(hdr));
+	memset(&hdr2, 0, sizeof(hdr2));
+	hdr.ssrc = 1;
+
+	err  = jbuf_alloc(&jb, 1, 10);
+	err |= jbuf_set_type(jb, JBUF_ADAPTIVE);
+	err |= jbuf_set_wish(jb, 2);
+	if (err)
+		return err;
+
+	for (i=0; i<ARRAY_SIZE(frv); i++) {
+		frv[i] = mem_zalloc(32, NULL);
+		if (!frv[i]) {
+			err = ENOMEM;
+			goto out;
+		}
+	}
+
+	/* Empty list */
+	DEBUG_INFO("test frame: Empty list\n");
+	if (ENOENT != jbuf_get(jb, &hdr2, &mem)) {
+		err = EINVAL;
+		goto out;
+	}
+
+
+	/* Two frames */
+	DEBUG_INFO("test frame: Two frames\n");
+	hdr.seq = 160;
+	err = jbuf_put(jb, &hdr, frv[0]);
+	if (err)
+		goto out;
+	if ((EALREADY != jbuf_put(jb, &hdr, frv[0]))) {err = EINVAL; goto out;}
+
+	/* wish size is not reached yet */
+	if (ENOENT != jbuf_get(jb, &hdr2, &mem)) {err = EINVAL; goto out;}
+
+	hdr.seq = 161;
+	hdr.ts = 20 * 8;
+	sys_msleep(20);
+	err = jbuf_put(jb, &hdr, frv[1]);
+	if (err)
+		goto out;
+
+	/* wish size reached */
+	err = jbuf_get(jb, &hdr2, &mem);
+	if (err)
+		goto out;
+
+	if (160 != hdr2.seq) {err = EINVAL; goto out;}
+	if (mem != frv[0]) {err = EINVAL; goto out;}
+	mem = mem_deref(mem);
+
+	if ((err = jbuf_get(jb, &hdr2, &mem)) || (161 != hdr2.seq)) {
+		err = err ? err : EINVAL; goto out; }
+	mem = mem_deref(mem);
+
+	if (ENOENT != jbuf_get(jb, &hdr2, &mem)) {err = EINVAL; goto out;}
+	mem = mem_deref(mem);
+
+	/* Four  frames */
+	DEBUG_INFO("test frame: Four frames\n");
+	hdr.seq = 320;
+	hdr.ts += 20 * 8;
+	sys_msleep(20);
+	err = jbuf_put(jb, &hdr, frv[0]);
+	if (err)
+		goto out;
+	hdr.seq = 480;
+	hdr.ts += 20 * 8;
+	sys_msleep(20);
+	err = jbuf_put(jb, &hdr, frv[1]);
+	if (err)
+		goto out;
+	hdr.seq = 490;
+	hdr.ts += 20 * 8;
+	sys_msleep(20);
+	err = jbuf_put(jb, &hdr, frv[2]);
+	if (err)
+		goto out;
+	hdr.seq = 491;
+	hdr.ts += 20 * 8;
+	sys_msleep(20);
+	err = jbuf_put(jb, &hdr, frv[3]);
+	if (err)
+		goto out;
+
+	err = jbuf_get(jb, &hdr2, &mem);
+	if (err)
+		goto out;
+	if (320 != hdr2.seq) {err = EINVAL; goto out;}
+	if (mem != frv[0]) {err = EINVAL; goto out;}
+	mem = mem_deref(mem);
+
+	err = jbuf_get(jb, &hdr2, &mem);
+	if (err)
+		goto out;
+	if (480 != hdr2.seq) {err = EINVAL; goto out;}
+	if (mem != frv[1]) {err = EINVAL; goto out;}
+	mem = mem_deref(mem);
+
+	err = jbuf_get(jb, &hdr2, &mem);
+	if (err)
+		goto out;
+	if (490 != hdr2.seq) {err = EINVAL; goto out;}
+	if (mem != frv[2]) {err = EINVAL; goto out;}
+	mem = mem_deref(mem);
+
+	err = jbuf_get(jb, &hdr2, &mem);
+	if (err)
+		goto out;
+	if (491 != hdr2.seq) {err = EINVAL; goto out;}
+	if (mem != frv[3]) {err = EINVAL; goto out;}
+	mem = mem_deref(mem);
+
+	if (ENOENT != jbuf_get(jb, &hdr2, &mem)) {err = EINVAL; goto out;}
+	mem = mem_deref(mem);
 
  out:
 	mem_deref(jb);

--- a/src/test.c
+++ b/src/test.c
@@ -88,6 +88,7 @@ static const struct test tests[] = {
 	TEST(test_ice_cand),
 	TEST(test_ice_loop),
 	TEST(test_jbuf),
+	TEST(test_jbuf_adaptive),
 	TEST(test_json),
 	TEST(test_json_file),
 	TEST(test_json_unicode),

--- a/src/test.h
+++ b/src/test.h
@@ -152,6 +152,7 @@ int test_httpauth_resp(void);
 int test_ice_loop(void);
 int test_ice_cand(void);
 int test_jbuf(void);
+int test_jbuf_adaptive(void);
 int test_json(void);
 int test_json_bad(void);
 int test_json_file(void);


### PR DESCRIPTION
- Fixes build since the jbuf_alloc() parameters had been extended by wish size
  and ptime.
- Adds tests for wish size.
- Fix valgrind warnings "Conditional jump depends on uninitialized value".

Related to: https://github.com/baresip/re/pull/41