### PR TITLE
tls: more generic function to set cafile and capath

### DIFF
--- a/src/sys.c
+++ b/src/sys.c
@@ -133,3 +133,31 @@ int test_sys_rand(void)
  out:
 	return err;
 }
+
+
+int test_sys_fs_isdir(void)
+{
+	int err = 0;
+	bool ret;
+	char path[256];
+	char file[256];
+	char *wpath = "/some/path/to/nothing";
+
+	re_snprintf(path, sizeof(path), "%s", test_datapath());
+	re_snprintf(file, sizeof(file), "%s/menu.json", test_datapath());
+
+	ret = fs_isdir(path);
+	TEST_EQUALS(true, ret);
+
+	ret = fs_isdir(NULL);
+	TEST_EQUALS(false, ret);
+
+	ret = fs_isdir(wpath);
+	TEST_EQUALS(false, ret);
+
+	ret = fs_isdir(file);
+	TEST_EQUALS(false, ret);
+
+ out:
+	return err;
+}

--- a/src/test.c
+++ b/src/test.c
@@ -160,6 +160,7 @@ static const struct test tests[] = {
 	TEST(test_tls_ec),
 	/*TEST(test_tls_selfsigned),*/
 	TEST(test_tls_certificate),
+	TEST(test_tls_false_cafile_path),
 #endif
 	TEST(test_tmr),
 	TEST(test_tmr_jiffies),

--- a/src/test.c
+++ b/src/test.c
@@ -153,6 +153,7 @@ static const struct test tests[] = {
 	TEST(test_sys_div),
 	TEST(test_sys_endian),
 	TEST(test_sys_rand),
+	TEST(test_sys_fs_isdir),
 	TEST(test_tcp),
 	TEST(test_telev),
 #ifdef USE_TLS

--- a/src/test.h
+++ b/src/test.h
@@ -230,6 +230,7 @@ int test_stun(void);
 int test_sys_div(void);
 int test_sys_endian(void);
 int test_sys_rand(void);
+int test_sys_fs_isdir(void);
 int test_tcp(void);
 int test_telev(void);
 int test_tmr(void);

--- a/src/test.h
+++ b/src/test.h
@@ -256,6 +256,7 @@ int test_tls(void);
 int test_tls_ec(void);
 int test_tls_selfsigned(void);
 int test_tls_certificate(void);
+int test_tls_false_cafile_path(void);
 #endif
 
 #ifdef USE_TLS

--- a/src/tls.c
+++ b/src/tls.c
@@ -370,3 +370,34 @@ int test_tls_certificate(void)
 	mem_deref(tls);
 	return err;
 }
+
+
+int test_tls_false_cafile_path(void)
+{
+	int err = 0;
+	struct tls *tls = NULL;
+	const char *cafile_wrong = "/some/path/to/wrong/file.crt";
+	const char *capath_wrong = "/some/path/to/nothing";
+
+	err = tls_alloc(&tls, TLS_METHOD_SSLV23, NULL, NULL);
+	if (err)
+		goto out;
+
+	err = tls_add_cafile_path(tls, NULL, NULL);
+	TEST_EQUALS(EINVAL, err);
+
+	err = tls_add_cafile_path(tls, cafile_wrong, NULL);
+	TEST_EQUALS(ENOENT, err);
+
+	err = tls_add_cafile_path(tls, NULL, capath_wrong);
+	TEST_EQUALS(ENOENT, err);
+
+	err = tls_add_cafile_path(tls, cafile_wrong, capath_wrong);
+	TEST_EQUALS(ENOENT, err);
+
+	err = 0;
+
+  out:
+	mem_deref(tls);
+	return err;
+}

--- a/src/tls.c
+++ b/src/tls.c
@@ -390,10 +390,10 @@ int test_tls_false_cafile_path(void)
 	TEST_EQUALS(ENOENT, err);
 
 	err = tls_add_cafile_path(tls, NULL, capath_wrong);
-	TEST_EQUALS(ENOENT, err);
+	TEST_EQUALS(ENOTDIR, err);
 
 	err = tls_add_cafile_path(tls, cafile_wrong, capath_wrong);
-	TEST_EQUALS(ENOENT, err);
+	TEST_EQUALS(ENOTDIR, err);
 
 	err = 0;
 


### PR DESCRIPTION
Negativ testcases where cafile and capath are wrong.
Testcases for fs_isdir