### PR TITLE
sa: lookup ifname for IPv6 link local scope interface

### DIFF
--- a/src/sa.c
+++ b/src/sa.c
@@ -311,12 +311,6 @@ int test_sa_pton(void)
 	uint32_t i;
 	char ifname[64];
 	char test_ipv6ll_scope[128] = "fe80::3a28:d8d9:ddc3:25dd%";
-
-	net_default_source_addr_get(AF_INET6, &sa_default_ip);
-	net_if_getname(ifname, sizeof(ifname), AF_INET6, &sa_default_ip);
-	re_snprintf(test_ipv6ll_scope, sizeof(test_ipv6ll_scope), "%s%s",
-		    test_ipv6ll_scope, ifname);
-
 	const struct {
 		const char *addr;
 		int err;
@@ -327,7 +321,6 @@ int test_sa_pton(void)
 		{"fa01::2a29", 0},
 		{"127.0.0.1", 0},
 		{"192.168.110.2", 0},
-		{test_ipv6ll_scope, 0},
 		{"fe80::xxxx:d8d9:ddc3:25dd:%eth0", EADDRNOTAVAIL},
 	};
 
@@ -336,9 +329,16 @@ int test_sa_pton(void)
 		TEST_EQUALS(testv[i].err, err);
 	}
 
-	err = 0;
+	net_default_source_addr_get(AF_INET6, &sa_default_ip);
+	net_if_getname(ifname, sizeof(ifname), AF_INET6, &sa_default_ip);
+	re_snprintf(test_ipv6ll_scope, sizeof(test_ipv6ll_scope), "%s%s",
+		    test_ipv6ll_scope, ifname);
+
+	err = sa_pton(test_ipv6ll_scope, &sa);
+	TEST_ERR(err);
+
 out:
-	if (err)
+	if (err && i < ARRAY_SIZE(testv))
 		DEBUG_WARNING("%s failed with addr %s\n", __func__,
 				testv[i].addr);
 

--- a/src/sa.c
+++ b/src/sa.c
@@ -329,8 +329,8 @@ int test_sa_pton(void)
 		TEST_EQUALS(testv[i].err, err);
 	}
 
-	net_default_source_addr_get(AF_INET6, &sa_default_ip);
-	net_if_getname(ifname, sizeof(ifname), AF_INET6, &sa_default_ip);
+	net_default_source_addr_get(AF_INET, &sa_default_ip);
+	net_if_getname(ifname, sizeof(ifname), AF_INET, &sa_default_ip);
 	re_snprintf(test_ipv6ll_scope, sizeof(test_ipv6ll_scope), "%s%s",
 		    test_ipv6ll_scope, ifname);
 
@@ -341,6 +341,9 @@ out:
 	if (err && i < ARRAY_SIZE(testv))
 		DEBUG_WARNING("%s failed with addr %s\n", __func__,
 				testv[i].addr);
+	else
+		DEBUG_WARNING("%s failed with addr %s\n", __func__,
+				test_ipv6ll_scope);
 
 	return err;
 }

--- a/src/sa.c
+++ b/src/sa.c
@@ -306,8 +306,16 @@ int test_sa_ntop(void)
 int test_sa_pton(void)
 {
 	struct sa sa;
+	struct sa sa_default_ip;
 	int err;
 	uint32_t i;
+	char ifname[64];
+	char test_ipv6ll_scope[128] = "fe80::3a28:d8d9:ddc3:25dd%";
+
+	net_default_source_addr_get(AF_INET6, &sa_default_ip);
+	net_if_getname(ifname, sizeof(ifname), AF_INET6, &sa_default_ip);
+	re_snprintf(test_ipv6ll_scope, sizeof(test_ipv6ll_scope), "%s%s",
+		    test_ipv6ll_scope, ifname);
 
 	const struct {
 		const char *addr;
@@ -319,7 +327,7 @@ int test_sa_pton(void)
 		{"fa01::2a29", 0},
 		{"127.0.0.1", 0},
 		{"192.168.110.2", 0},
-		{"fe80::3a28:d8d9:ddc3:25dd%eth0", 0},
+		{test_ipv6ll_scope, 0},
 		{"fe80::xxxx:d8d9:ddc3:25dd:%eth0", EADDRNOTAVAIL},
 	};
 

--- a/src/sa.c
+++ b/src/sa.c
@@ -329,6 +329,7 @@ int test_sa_pton(void)
 		TEST_EQUALS(testv[i].err, err);
 	}
 
+	/* Use IPv4 since not all test systems have a default IPv6 route */
 	net_default_source_addr_get(AF_INET, &sa_default_ip);
 	net_if_getname(ifname, sizeof(ifname), AF_INET, &sa_default_ip);
 	re_snprintf(test_ipv6ll_scope, sizeof(test_ipv6ll_scope), "%s%s",

--- a/src/sa.c
+++ b/src/sa.c
@@ -342,7 +342,7 @@ out:
 	if (err && i < ARRAY_SIZE(testv))
 		DEBUG_WARNING("%s failed with addr %s\n", __func__,
 				testv[i].addr);
-	else
+	else if (err)
 		DEBUG_WARNING("%s failed with addr %s\n", __func__,
 				test_ipv6ll_scope);
 


### PR DESCRIPTION
Not every test system has an `eth0` interface.
