### PR TITLE
dns: init struct

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -363,7 +363,7 @@ out:
 int test_dns_integration(void)
 {
 	struct dns_server *srv = NULL;
-	struct test_dns data;
+	struct test_dns data = {0};
 	struct dns_query *q;
 	int err;
 


### PR DESCRIPTION
```
New defect(s) Reported-by: Coverity Scan
Showing 1 of 1 defect(s)


** CID 1490848:  Memory - illegal accesses  (UNINIT)
/src/dns.c: 442 in test_dns_integration()


________________________________________________________________________________________________________
*** CID 1490848:  Memory - illegal accesses  (UNINIT)
/src/dns.c: 442 in test_dns_integration()
436     	/* --- Leave query open for cleanup test --- */
437     	err = dnsc_query(&q, data.dnsc, "test1.example.net", DNS_TYPE_A,
438     			 DNS_CLASS_IN, true, query_handler, &data);
439     	TEST_ERR(err);
440     
441     out:
>>>     CID 1490848:  Memory - illegal accesses  (UNINIT)
>>>     Using uninitialized value "data.dnsc" when calling "mem_deref".
442     	mem_deref(data.dnsc);
443     	mem_deref(srv);
444     
445     	return err;
```
