### PR TITLE
tls: remove some warnings

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -525,7 +525,7 @@ int test_tls_cli_conn_change_cert(void)
 		"%s/not_a_file.pem", test_datapath());
 
 	err = tls_conn_change_cert(tt.sc_cli, clientcert);
-	TEST_EQUALS(EINVAL, err);
+	TEST_EQUALS(ENOENT, err);
 
 	memset(clientcert, 0, sizeof(clientcert));
 	(void)re_snprintf(clientcert, sizeof(clientcert),

--- a/src/tls.c
+++ b/src/tls.c
@@ -524,8 +524,8 @@ int test_tls_cli_conn_change_cert(void)
 	(void)re_snprintf(clientcert, sizeof(clientcert),
 		"%s/not_a_file.pem", test_datapath());
 
-	err = tls_conn_change_cert(tt.sc_cli, clientcert);
-	TEST_EQUALS(ENOENT, err);
+	int ret = tls_conn_change_cert(tt.sc_cli, clientcert);
+	ASSERT_TRUE(ret==EINVAL || ret==ENOENT);
 
 	memset(clientcert, 0, sizeof(clientcert));
 	(void)re_snprintf(clientcert, sizeof(clientcert),


### PR DESCRIPTION
NOTE: made the test a bit flexible, so that it can handle old and new versions of re.