### PR TITLE
tls: missing reset of TCP connection established flag

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -288,6 +288,7 @@ static int test_tls_base(enum tls_keytype keytype, bool add_ca, int exp_verr,
 		tt.tc_cli = mem_deref(tt.tc_cli);
 		tt.tc_srv = mem_deref(tt.tc_srv);
 		tt.estab_cli = false;
+		tt.estab_srv = false;
 		tt.recv_cli = 0;
 	}
 


### PR DESCRIPTION
The flag that indicates that the local TCP server to remote TCP client
connection was established has to be reset to false if the TCP connection is
closed.

Was found during working on: https://github.com/baresip/re/pull/607