### PR TITLE
PRACK refactoring

### DIFF
--- a/src/sipsess.c
+++ b/src/sipsess.c
@@ -13,12 +13,28 @@
 #include <re_dbg.h>
 
 
+typedef void (prack_func)(void *arg);
+
+
 enum sdp_neg_state {
 	INITIAL = 0,
 	OFFER_RECEIVED,
 	ANSWER_RECEIVED,
-	EARLY_CONFIRMED,
-	PRACK_ANSWERED
+	EARLY_CONFIRMED
+};
+
+
+enum rel100_state {
+	REL100_NONE = 0,
+	REL100_SUPPORTED = 1,
+	REL100_REQUIRE = 2
+};
+
+
+enum connect_action {
+	CONN_PROGRESS = 1,
+	CONN_PROGR_ANS = 2,
+	CONN_ANSWER = 4
 };
 
 
@@ -39,10 +55,13 @@ struct test {
 	enum rel100_mode rel100_a;
 	enum rel100_mode rel100_b;
 	enum sdp_neg_state sdp_state;
-	bool req_received_a;
-	bool req_received_b;
-	bool sup_received_a;
-	bool sup_received_b;
+	enum rel100_state rel100_state_a;
+	enum rel100_state rel100_state_b;
+	enum connect_action conn_action;
+	prack_func *prack_action;
+	bool answer_on_connect;
+	int progr_ret_code;
+	int answ_ret_code;
 	bool upd_a;
 	bool upd_b;
 	struct mbuf *desc;
@@ -111,6 +130,60 @@ static void send_answer_b(void *arg)
 }
 
 
+static void send_update_a(void *arg)
+{
+	struct test *test = arg;
+	struct mbuf *desc;
+	int err;
+
+	desc = mbuf_alloc(sizeof(sdp_a));
+	if (!desc) {
+		err = ENOMEM;
+		goto out;
+	}
+	err = mbuf_write_str(desc, sdp_a);
+	TEST_ERR(err);
+
+	mbuf_set_pos(desc, 0);
+
+	err = sipsess_modify(test->a, desc);
+	TEST_ERR(err);
+
+out:
+	mem_deref(desc);
+	if (err)
+		abort_test(test, err);
+
+}
+
+
+static void send_update_b(void *arg)
+{
+	struct test *test = arg;
+	struct mbuf *desc;
+	int err;
+
+	desc = mbuf_alloc(sizeof(sdp_b));
+	if (!desc) {
+		err = ENOMEM;
+		goto out;
+	}
+	err = mbuf_write_str(desc, sdp_b);
+	TEST_ERR(err);
+
+	mbuf_set_pos(desc, 0);
+
+	err = sipsess_modify(test->b, desc);
+	TEST_ERR(err);
+
+out:
+	mem_deref(desc);
+	if (err)
+		abort_test(test, err);
+
+}
+
+
 static int desc_handler(struct mbuf **descp, const struct sa *src,
 				const struct sa *dst, void *arg)
 {
@@ -141,34 +214,11 @@ static int desc_handler_a(struct mbuf **descp, const struct sa *src,
 		err = ENOMEM;
 		goto out;
 	}
+
 	err = mbuf_write_str(desc, sdp_a);
 	if (err)
 		goto out;
-	mbuf_set_pos(desc, 0);
-	*descp = desc;
 
-out:
-	return err;
-}
-
-
-static int desc_handler_b(struct mbuf **descp, const struct sa *src,
-				const struct sa *dst, void *arg)
-{
-	struct mbuf *desc;
-	int err = 0;
-	(void)src;
-	(void)dst;
-	(void)arg;
-
-	desc = mbuf_alloc(sizeof(sdp_b));
-	if (!desc) {
-		err = ENOMEM;
-		goto out;
-	}
-	err = mbuf_write_str(desc, sdp_b);
-	if (err)
-		goto out;
 	mbuf_set_pos(desc, 0);
 	*descp = desc;
 
@@ -184,81 +234,15 @@ static int offer_handler_a(struct mbuf **descp, const struct sip_msg *msg,
 	(void)descp;
 	(void)msg;
 
-	if (test->sdp_state == INITIAL || test->sdp_state == EARLY_CONFIRMED
-	    || test->sdp_state == PRACK_ANSWERED)
+	if (test->sdp_state == INITIAL || test->sdp_state == EARLY_CONFIRMED)
 		test->sdp_state = OFFER_RECEIVED;
-
-
-	test->offer_a = true;
-	return 0;
-}
-
-
-static int offer_handler_update_a(struct mbuf **descp,
-				   const struct sip_msg *msg, void *arg)
-{
-	struct test *test = arg;
-	struct mbuf *desc;
-	int err = 0;
-	(void)msg;
-
-	if (test->sdp_state == INITIAL || test->sdp_state == EARLY_CONFIRMED
-	    || test->sdp_state == PRACK_ANSWERED)
-		test->sdp_state = OFFER_RECEIVED;
-
 
 	if (!pl_strcmp(&msg->met, "UPDATE"))
 		test->upd_a = true;
 
-	desc = mbuf_alloc(sizeof(sdp_a));
-	if (!desc) {
-		err = ENOMEM;
-		goto out;
-	}
-	err = mbuf_write_str(desc, sdp_a);
-	if (err)
-		goto out;
-	mbuf_set_pos(desc, 0);
-	*descp = desc;
-
-out:
 	test->offer_a = true;
-	return err;
-}
 
-
-static int offer_handler_update_b(struct mbuf **descp,
-				   const struct sip_msg *msg, void *arg)
-{
-	struct test *test = arg;
-	struct mbuf *desc;
-	int err = 0;
-	(void)msg;
-
-	test->sdp_state = OFFER_RECEIVED;
-
-	if (test->sdp_state == INITIAL || test->sdp_state == EARLY_CONFIRMED
-	    || test->sdp_state == PRACK_ANSWERED)
-		test->sdp_state = OFFER_RECEIVED;
-
-
-	if (!pl_strcmp(&msg->met, "UPDATE"))
-		test->upd_b = true;
-
-	desc = mbuf_alloc(sizeof(sdp_b));
-	if (!desc) {
-		err = ENOMEM;
-		goto out;
-	}
-	err = mbuf_write_str(desc, sdp_b);
-	if (err)
-		goto out;
-	mbuf_set_pos(desc, 0);
-	*descp = desc;
-
-out:
-	test->offer_b = true;
-	return err;
+	return 0;
 }
 
 
@@ -269,13 +253,14 @@ static int offer_handler_b(struct mbuf **descp, const struct sip_msg *msg,
 	(void)descp;
 	(void)msg;
 
-	test->sdp_state = OFFER_RECEIVED;
-
-	if (test->sdp_state == INITIAL || test->sdp_state == EARLY_CONFIRMED
-	    || test->sdp_state == PRACK_ANSWERED)
+	if (test->sdp_state == INITIAL || test->sdp_state == EARLY_CONFIRMED)
 		test->sdp_state = OFFER_RECEIVED;
 
+	if (!pl_strcmp(&msg->met, "UPDATE"))
+		test->upd_b = true;
+
 	test->offer_b = true;
+
 	return 0;
 }
 
@@ -287,16 +272,18 @@ static int answer_handler_a(const struct sip_msg *msg, void *arg)
 	if (mbuf_get_left(msg->mb))
 		test->sdp_state = ANSWER_RECEIVED;
 
-	test->sup_received_a = sip_msg_hdr_has_value(msg, SIP_HDR_SUPPORTED,
-						     "100rel");
-	test->req_received_a = sip_msg_hdr_has_value(msg, SIP_HDR_REQUIRE,
-						     "100rel");
+	if (sip_msg_hdr_has_value(msg, SIP_HDR_SUPPORTED, "100rel"))
+		test->rel100_a |= REL100_SUPPORTED;
+
+	if (sip_msg_hdr_has_value(msg, SIP_HDR_REQUIRE, "100rel"))
+		test->rel100_a |= REL100_REQUIRE;
 
 	if (!pl_strcmp(&msg->cseq.met, "UPDATE")) {
 		if (msg->scode < 200 || msg->scode > 299) {
 			abort_test(test, msg->scode);
 			return msg->scode;
 		}
+
 		tmr_start(&test->ans_tmr, 0, send_answer_b, test);
 	}
 
@@ -307,22 +294,22 @@ static int answer_handler_a(const struct sip_msg *msg, void *arg)
 static int answer_handler_b(const struct sip_msg *msg, void *arg)
 {
 	struct test *test = arg;
-	(void)msg;
 	test->answr_b = true;
-	test->sdp_state = ANSWER_RECEIVED;
+	if (mbuf_get_left(msg->mb))
+		test->sdp_state = ANSWER_RECEIVED;
 
-	test->sup_received_b = test->sup_received_b ? test->sup_received_b :
-				sip_msg_hdr_has_value(msg, SIP_HDR_SUPPORTED,
-						     "100rel");
-	test->req_received_b = test->req_received_b ? test->req_received_b :
-				sip_msg_hdr_has_value(msg, SIP_HDR_REQUIRE,
-						     "100rel");
+	if (sip_msg_hdr_has_value(msg, SIP_HDR_SUPPORTED, "100rel"))
+		test->rel100_state_b |= REL100_SUPPORTED;
+
+	if (sip_msg_hdr_has_value(msg, SIP_HDR_REQUIRE, "100rel"))
+		test->rel100_state_b |= REL100_REQUIRE;
 
 	if (!pl_strcmp(&msg->cseq.met, "UPDATE")) {
 		if (msg->scode < 200 || msg->scode > 299) {
 			abort_test(test, msg->scode);
 			return msg->scode;
 		}
+
 		tmr_start(&test->ans_tmr, 0, send_answer_b, test);
 	}
 
@@ -339,99 +326,24 @@ static void progr_handler_a(const struct sip_msg *msg, void *arg)
 }
 
 
-static void send_update_a(void *arg)
-{
-	struct test *test = arg;
-	struct mbuf *desc;
-	int err;
-
-	desc = mbuf_alloc(sizeof(sdp_a));
-	if (!desc) {
-		err = ENOMEM;
-		goto out;
-	}
-	err = mbuf_write_str(desc, sdp_a);
-	TEST_ERR(err);
-	mbuf_set_pos(desc, 0);
-
-	err = sipsess_modify(test->a, desc);
-	TEST_ERR(err);
-
-out:
-	mem_deref(desc);
-	if (err)
-		abort_test(test, err);
-
-}
-
-
-static void send_update_b(void *arg)
-{
-	struct test *test = arg;
-	struct mbuf *desc;
-	int err;
-
-	desc = mbuf_alloc(sizeof(sdp_b));
-	if (!desc) {
-		err = ENOMEM;
-		goto out;
-	}
-	err = mbuf_write_str(desc, sdp_b);
-	TEST_ERR(err);
-	mbuf_set_pos(desc, 0);
-
-	err = sipsess_modify(test->b, desc);
-	TEST_ERR(err);
-
-out:
-	mem_deref(desc);
-	if (err)
-		abort_test(test, err);
-
-}
-
-
 static void prack_handler(const struct sip_msg *msg, void *arg)
 {
 	struct test *test = arg;
+	(void)msg;
 
-	(void) msg;
+	if (test->sdp_state == ANSWER_RECEIVED)
+		test->sdp_state = EARLY_CONFIRMED;
 
-	test->sdp_state = EARLY_CONFIRMED;
-	tmr_start(&test->ans_tmr, 0, send_answer_b, test);
-}
-
-
-static void prack_handler_update_b(const struct sip_msg *msg, void *arg)
-{
-	struct test *test = arg;
-
-	(void) msg;
-
-	test->sdp_state = EARLY_CONFIRMED;
-	tmr_start(&test->ans_tmr, 0, send_update_b, test);
-}
-
-
-static void prack_handler_update(const struct sip_msg *msg, void *arg)
-{
-	struct test *test = arg;
-
-	(void) msg;
-
-	test->sdp_state = EARLY_CONFIRMED;
-	tmr_start(&test->ans_tmr, 0, send_update_a, test);
+	tmr_start(&test->ans_tmr, 0, test->prack_action, test);
 }
 
 
 static void estab_handler_a(const struct sip_msg *msg, void *arg)
 {
 	struct test *test = arg;
-
 	(void)msg;
 
 	test->estab_a = true;
-
 	if (test->estab_b)
 		stop_test();
 }
@@ -440,11 +352,9 @@ static void estab_handler_a(const struct sip_msg *msg, void *arg)
 static void estab_handler_b(const struct sip_msg *msg, void *arg)
 {
 	struct test *test = arg;
-
 	(void)msg;
 
 	test->estab_b = true;
-
 	if (test->estab_a)
 		stop_test();
 }
@@ -453,308 +363,17 @@ static void estab_handler_b(const struct sip_msg *msg, void *arg)
 static void close_handler(int err, const struct sip_msg *msg, void *arg)
 {
 	struct test *test = arg;
-
-	(void)err;
 	(void)msg;
-	(void)arg;
 
 	abort_test(test, err ? err : ENOMEM);
-}
-
-
-static void conn_handler_100rel_answer(const struct sip_msg *msg, void *arg)
-{
-	struct test *test = arg;
-	struct mbuf *desc;
-	int err;
-	char *hdrs = test->rel100_b == REL100_REQUIRED ?
-		     "Require: 100rel\r\n" : "";
-	(void)arg;
-
-	if (mbuf_get_left(msg->mb)) {
-		test->sdp_state = OFFER_RECEIVED;
-		test->offer_b = true;
-	}
-
-	test->sup_received_b = test->sup_received_b ? test->sup_received_b :
-				sip_msg_hdr_has_value(msg, SIP_HDR_SUPPORTED,
-						     "100rel");
-	test->req_received_b = test->req_received_b ? test->req_received_b :
-				sip_msg_hdr_has_value(msg, SIP_HDR_REQUIRE,
-						     "100rel");
-
-	desc = mbuf_alloc(sizeof(sdp_b));
-	if (!desc) {
-		abort_test(test, ENOMEM);
-		return;
-	}
-	err = mbuf_write_str(desc, sdp_b);
-	if (err) {
-		abort_test(test, err);
-		return;
-	}
-	mbuf_set_pos(desc, 0);
-	test->desc = desc;
-
-	err = sipsess_set_prack_handler(test->b, prack_handler);
-	if (err)
-		abort_test(test, err);
-
-	err = sipsess_accept(&test->b, test->sock, msg, 183, "Progress",
-			     test->rel100_b, "b", "application/sdp",
-			     desc, NULL, NULL, false, offer_handler_update_b,
-			     answer_handler_b, estab_handler_b, NULL, NULL,
-			     close_handler, test, hdrs);
-	if (err) {
-		abort_test(test, err);
-	}
-
-	err = sipsess_answer(test->b, 200, "Answering", NULL, NULL);
-	if (err) {
-		abort_test(test, -256);
-	}
-}
-
-
-static void conn_handler_420(const struct sip_msg *msg, void *arg)
-{
-	struct test *test = arg;
-	struct mbuf *desc;
-	int err;
-	char *hdrs = test->rel100_b == REL100_REQUIRED ?
-		     "Require: 100rel\r\n" : "";
-	(void)arg;
-
-	if (mbuf_get_left(msg->mb)) {
-		test->sdp_state = OFFER_RECEIVED;
-		test->offer_b = true;
-	}
-
-	test->sup_received_b = test->sup_received_b ? test->sup_received_b :
-				sip_msg_hdr_has_value(msg, SIP_HDR_SUPPORTED,
-						     "100rel");
-	test->req_received_b = test->req_received_b ? test->req_received_b :
-				sip_msg_hdr_has_value(msg, SIP_HDR_REQUIRE,
-						     "100rel");
-
-	desc = mbuf_alloc(sizeof(sdp_b));
-	if (!desc) {
-		abort_test(test, ENOMEM);
-		return;
-	}
-	err = mbuf_write_str(desc, sdp_b);
-	TEST_ERR(err);
-
-	mbuf_set_pos(desc, 0);
-	test->desc = desc;
-
-	err = sipsess_accept(&test->b, test->sock, msg, 183, "Progress",
-			     test->rel100_b, "b", "application/sdp",
-			     desc, NULL, NULL, false, offer_handler_update_b,
-			     answer_handler_b, estab_handler_b, NULL, NULL,
-			     close_handler, test, hdrs);
-	TEST_ASSERT(err == -1);
-	mem_deref(desc);
-	return;
-
-out:
-	mem_deref(desc);
-	if (err)
-		abort_test(test, err);
-}
-
-
-static void conn_handler_100rel(const struct sip_msg *msg, void *arg)
-{
-	struct test *test = arg;
-	struct mbuf *desc;
-	int err;
-	char *hdrs = test->rel100_b == REL100_REQUIRED ?
-		     "Require: 100rel\r\n" : "";
-	(void)arg;
-
-	if (mbuf_get_left(msg->mb)) {
-		test->sdp_state = OFFER_RECEIVED;
-		test->offer_b = true;
-	}
-
-	test->sup_received_b = test->sup_received_b ? test->sup_received_b :
-				sip_msg_hdr_has_value(msg, SIP_HDR_SUPPORTED,
-						     "100rel");
-	test->req_received_b = test->req_received_b ? test->req_received_b :
-				sip_msg_hdr_has_value(msg, SIP_HDR_REQUIRE,
-						     "100rel");
-
-	desc = mbuf_alloc(sizeof(sdp_b));
-	if (!desc) {
-		abort_test(test, ENOMEM);
-		return;
-	}
-	err = mbuf_write_str(desc, sdp_b);
-	TEST_ERR(err);
-
-	mbuf_set_pos(desc, 0);
-	test->desc = desc;
-
-	err = sipsess_accept(&test->b, test->sock, msg, 183, "Progress",
-			     test->rel100_b, "b", "application/sdp",
-			     desc, NULL, NULL, false, offer_handler_update_b,
-			     answer_handler_b, estab_handler_b, NULL, NULL,
-			     close_handler, test, hdrs);
-	TEST_ERR(err);
-	return;
-
-out:
-	mem_deref(desc);
-	if (err)
-		abort_test(test, err);
-}
-
-
-static void conn_handler_prack(const struct sip_msg *msg, void *arg)
-{
-	struct test *test = arg;
-	struct mbuf *desc;
-	int err;
-	char *hdrs = test->rel100_b == REL100_REQUIRED ?
-		     "Require: 100rel\r\n" : "";
-	(void)arg;
-
-	if (mbuf_get_left(msg->mb)) {
-		test->sdp_state = OFFER_RECEIVED;
-		test->offer_b = true;
-	}
-
-	test->sup_received_b = test->sup_received_b ? test->sup_received_b :
-				sip_msg_hdr_has_value(msg, SIP_HDR_SUPPORTED,
-						     "100rel");
-	test->req_received_b = test->req_received_b ? test->req_received_b :
-				sip_msg_hdr_has_value(msg, SIP_HDR_REQUIRE,
-						     "100rel");
-
-	desc = mbuf_alloc(sizeof(sdp_b));
-	if (!desc) {
-		abort_test(test, ENOMEM);
-		return;
-	}
-	err = mbuf_write_str(desc, sdp_b);
-	if (err) {
-		abort_test(test, err);
-		return;
-	}
-	mbuf_set_pos(desc, 0);
-	test->desc = desc;
-
-	(void)sipsess_accept(&test->b, test->sock, msg, 183, "Progress",
-			     test->rel100_b, "b", "application/sdp",
-			     desc, NULL, NULL, false, offer_handler_update_b,
-			     answer_handler_b, estab_handler_b, NULL, NULL,
-			     close_handler, test, hdrs);
-
-	err = sipsess_set_prack_handler(test->b, prack_handler);
-	if (err)
-		abort_test(test, err);
-}
-
-
-static void conn_handler_update_b(const struct sip_msg *msg, void *arg)
-{
-	struct test *test = arg;
-	struct mbuf *desc;
-	int err;
-	char *hdrs = test->rel100_b == REL100_REQUIRED ?
-		     "Require: 100rel\r\n" : "";
-	(void)arg;
-
-	if (mbuf_get_left(msg->mb)) {
-		test->sdp_state = OFFER_RECEIVED;
-		test->offer_b = true;
-	}
-
-	test->sup_received_b = test->sup_received_b ? test->sup_received_b :
-				sip_msg_hdr_has_value(msg, SIP_HDR_SUPPORTED,
-						     "100rel");
-	test->req_received_b = test->req_received_b ? test->req_received_b :
-				sip_msg_hdr_has_value(msg, SIP_HDR_REQUIRE,
-						     "100rel");
-
-	desc = mbuf_alloc(sizeof(sdp_b));
-	if (!desc) {
-		abort_test(test, ENOMEM);
-		return;
-	}
-	err = mbuf_write_str(desc, sdp_b);
-	if (err) {
-		abort_test(test, err);
-		return;
-	}
-	mbuf_set_pos(desc, 0);
-	test->desc = desc;
-
-	(void)sipsess_accept(&test->b, test->sock, msg, 183, "Progress",
-			     test->rel100_b, "b", "application/sdp",
-			     desc, NULL, NULL, false, offer_handler_update_b,
-			     answer_handler_b, estab_handler_b, NULL, NULL,
-			     close_handler, test, hdrs);
-
-	err = sipsess_set_prack_handler(test->b, prack_handler_update_b);
-	if (err)
-		abort_test(test, err);
-}
-
-
-static void conn_handler_update(const struct sip_msg *msg, void *arg)
-{
-	struct test *test = arg;
-	struct mbuf *desc;
-	int err;
-	char *hdrs = test->rel100_b == REL100_REQUIRED ?
-		     "Require: 100rel\r\n" : "";
-	(void)arg;
-
-	if (mbuf_get_left(msg->mb)) {
-		test->sdp_state = OFFER_RECEIVED;
-		test->offer_b = true;
-	}
-
-	test->sup_received_b = test->sup_received_b ? test->sup_received_b :
-				sip_msg_hdr_has_value(msg, SIP_HDR_SUPPORTED,
-						     "100rel");
-	test->req_received_b = test->req_received_b ? test->req_received_b :
-				sip_msg_hdr_has_value(msg, SIP_HDR_REQUIRE,
-						     "100rel");
-
-	desc = mbuf_alloc(sizeof(sdp_b));
-	if (!desc) {
-		abort_test(test, ENOMEM);
-		return;
-	}
-	err = mbuf_write_str(desc, sdp_b);
-	if (err) {
-		abort_test(test, err);
-		return;
-	}
-	mbuf_set_pos(desc, 0);
-	test->desc = desc;
-
-	(void)sipsess_accept(&test->b, test->sock, msg, 183, "Progress",
-			     test->rel100_b, "b", "application/sdp",
-			     desc, NULL, NULL, false, offer_handler_update_b,
-			     answer_handler_b, estab_handler_b, NULL, NULL,
-			     close_handler, test, hdrs);
-
-	err = sipsess_set_prack_handler(test->b, prack_handler_update);
-	if (err)
-		abort_test(test, err);
 }
 
 
 static void conn_handler(const struct sip_msg *msg, void *arg)
 {
 	struct test *test = arg;
-	(void)arg;
+	struct mbuf *desc;
 	int err;
-
 	char *hdrs = test->rel100_b == REL100_REQUIRED ?
 		     "Require: 100rel\r\n" : "";
 
@@ -763,14 +382,76 @@ static void conn_handler(const struct sip_msg *msg, void *arg)
 		test->offer_b = true;
 	}
 
-	err = sipsess_accept(&test->b, test->sock, msg, 200, "OK",
-			     test->rel100_b, "b", "application/sdp",
-			     NULL, NULL, NULL, false, offer_handler_b,
-			     answer_handler_b, estab_handler_b, NULL, NULL,
-			     close_handler, test, hdrs);
+	if (sip_msg_hdr_has_value(msg, SIP_HDR_SUPPORTED, "100rel"))
+		test->rel100_state_b |= REL100_SUPPORTED;
+
+	if (sip_msg_hdr_has_value(msg, SIP_HDR_REQUIRE, "100rel"))
+		test->rel100_state_b |= REL100_REQUIRE;
+
+	desc = mbuf_alloc(sizeof(sdp_b));
+	if (!desc) {
+		abort_test(test, ENOMEM);
+		return;
+	}
+
+	err = mbuf_write_str(desc, sdp_b);
 	if (err) {
 		abort_test(test, err);
+		return;
 	}
+
+	mbuf_set_pos(desc, 0);
+	test->desc = desc;
+
+	if (test->conn_action & CONN_PROGRESS
+	    || test->conn_action & CONN_PROGR_ANS) {
+		err = sipsess_accept(&test->b, test->sock, msg, 183,
+				"Progress", test->rel100_b, "b",
+				"application/sdp", desc, NULL, NULL, false,
+				offer_handler_b, answer_handler_b,
+				estab_handler_b, NULL, NULL, close_handler,
+				test, hdrs);
+		if (err != test->progr_ret_code) {
+			test->progr_ret_code = err;
+			goto out;
+		}
+
+		if (err)
+			mem_deref(desc);
+
+		err = sipsess_set_prack_handler(test->b, prack_handler);
+		if (err)
+			abort_test(test, err);
+	}
+
+	if (test->conn_action & CONN_PROGR_ANS) {
+		err = sipsess_answer(test->b, 200, "Answering", NULL, NULL);
+		if (err != test->answ_ret_code) {
+			test->answ_ret_code = err;
+			goto out;
+		}
+	}
+	else if (test->conn_action & CONN_ANSWER) {
+		err = sipsess_accept(&test->b, test->sock, msg, 200, "OK",
+				test->rel100_b, "b", "application/sdp",
+				NULL, NULL, NULL, false, offer_handler_b,
+				answer_handler_b, estab_handler_b, NULL, NULL,
+				close_handler, test, hdrs);
+		if (err != test->answ_ret_code) {
+			test->answ_ret_code = err;
+			goto out;
+		}
+	}
+
+	if (test->conn_action & CONN_ANSWER
+	    || test->conn_action & CONN_PROGR_ANS)
+		mem_deref(desc);
+
+	return;
+
+out:
+	mem_deref(desc);
+	abort_test(test, err);
 }
 
 
@@ -820,6 +501,7 @@ int test_sipsess(void)
 
 	test.rel100_a = REL100_ENABLED;
 	test.rel100_b = REL100_ENABLED;
+	test.conn_action = CONN_ANSWER;
 
 	err = sip_alloc(&test.sip, NULL, 32, 32, 32,
 			"retest", exit_handler, NULL);
@@ -868,11 +550,11 @@ int test_sipsess(void)
 	}
 
 	/* okay here -- verify */
-	TEST_ASSERT(test.estab_a);
-	TEST_ASSERT(test.estab_b);
-	TEST_ASSERT(test.desc);
-	TEST_ASSERT(test.answr_a);
-	TEST_ASSERT(!test.offer_b);
+	ASSERT_TRUE(test.estab_a);
+	ASSERT_TRUE(test.estab_b);
+	ASSERT_TRUE(test.desc);
+	ASSERT_TRUE(test.answr_a);
+	ASSERT_TRUE(!test.offer_b);
 
  out:
 	test.a = mem_deref(test.a);
@@ -901,6 +583,7 @@ int test_sipsess_blind_transfer(void)
 
 	test.rel100_a = REL100_ENABLED;
 	test.rel100_b = REL100_ENABLED;
+	test.conn_action = CONN_ANSWER;
 
 	err = sip_alloc(&test.sip, NULL, 32, 32, 32,
 			"retest", exit_handler, NULL);
@@ -956,12 +639,12 @@ int test_sipsess_blind_transfer(void)
 	}
 
 	/* okay here -- verify */
-	TEST_ASSERT(test.blind_transfer);
-	TEST_ASSERT(test.estab_a);
-	TEST_ASSERT(test.estab_b);
-	TEST_ASSERT(test.desc);
-	TEST_ASSERT(test.answr_a);
-	TEST_ASSERT(!test.offer_b);
+	ASSERT_TRUE(test.blind_transfer);
+	ASSERT_TRUE(test.estab_a);
+	ASSERT_TRUE(test.estab_b);
+	ASSERT_TRUE(test.desc);
+	ASSERT_TRUE(test.answr_a);
+	ASSERT_TRUE(!test.offer_b);
 
  out:
 	test.a = mem_deref(test.a);
@@ -989,6 +672,8 @@ int test_sipsess_100rel_caller_require(void)
 
 	test.rel100_a = REL100_REQUIRED;
 	test.rel100_b = REL100_ENABLED;
+	test.conn_action = CONN_PROGRESS;
+	test.prack_action = send_answer_b;
 
 	err = sip_alloc(&test.sip, NULL, 32, 32, 32,
 			"retest", exit_handler, NULL);
@@ -1003,7 +688,7 @@ int test_sipsess_100rel_caller_require(void)
 
 	port = sa_port(&laddr);
 
-	err = sipsess_listen(&test.sock, test.sip, 32, conn_handler_prack,
+	err = sipsess_listen(&test.sock, test.sip, 32, conn_handler,
 			     &test);
 	TEST_ERR(err);
 
@@ -1032,15 +717,15 @@ int test_sipsess_100rel_caller_require(void)
 	}
 
 	/* okay here -- verify */
-	TEST_ASSERT(test.estab_a);
-	TEST_ASSERT(test.estab_b);
-	TEST_ASSERT(test.desc);
-	TEST_ASSERT(test.offer_b);
-	TEST_ASSERT(!test.answr_b);
-	TEST_ASSERT(test.progr_a);
-	TEST_ASSERT(test.req_received_b);
-	TEST_ASSERT(!test.sup_received_b);
-	TEST_ASSERT(test.sdp_state == EARLY_CONFIRMED);
+	ASSERT_TRUE(test.estab_a);
+	ASSERT_TRUE(test.estab_b);
+	ASSERT_TRUE(test.desc);
+	ASSERT_TRUE(test.offer_b);
+	ASSERT_TRUE(!test.answr_b);
+	ASSERT_TRUE(test.progr_a);
+	ASSERT_TRUE(test.rel100_state_b & REL100_REQUIRE);
+	ASSERT_TRUE((test.rel100_state_b & REL100_SUPPORTED) == 0);
+	ASSERT_TRUE(test.sdp_state == EARLY_CONFIRMED);
 
 out:
 	test.a = mem_deref(test.a);
@@ -1071,6 +756,8 @@ int test_sipsess_100rel_supported(void)
 
 	test.rel100_a = REL100_ENABLED;
 	test.rel100_b = REL100_ENABLED;
+	test.conn_action = CONN_PROGRESS;
+	test.prack_action = send_answer_b;
 
 	err = sip_alloc(&test.sip, NULL, 32, 32, 32,
 			"retest", exit_handler, NULL);
@@ -1085,7 +772,7 @@ int test_sipsess_100rel_supported(void)
 
 	port = sa_port(&laddr);
 
-	err = sipsess_listen(&test.sock, test.sip, 32, conn_handler_prack,
+	err = sipsess_listen(&test.sock, test.sip, 32, conn_handler,
 			     &test);
 	TEST_ERR(err);
 
@@ -1114,17 +801,17 @@ int test_sipsess_100rel_supported(void)
 	}
 
 	/* okay here -- verify */
-	TEST_ASSERT(test.estab_a);
-	TEST_ASSERT(test.estab_b);
-	TEST_ASSERT(test.desc);
-	TEST_ASSERT(test.answr_a);
-	TEST_ASSERT(!test.offer_a);
-	TEST_ASSERT(test.offer_b);
-	TEST_ASSERT(!test.answr_b);
-	TEST_ASSERT(test.progr_a);
-	TEST_ASSERT(test.sup_received_b);
-	TEST_ASSERT(!test.req_received_b);
-	TEST_ASSERT(test.sdp_state == EARLY_CONFIRMED);
+	ASSERT_TRUE(test.estab_a);
+	ASSERT_TRUE(test.estab_b);
+	ASSERT_TRUE(test.desc);
+	ASSERT_TRUE(test.answr_a);
+	ASSERT_TRUE(!test.offer_a);
+	ASSERT_TRUE(test.offer_b);
+	ASSERT_TRUE(!test.answr_b);
+	ASSERT_TRUE(test.progr_a);
+	ASSERT_TRUE(test.rel100_state_b & REL100_SUPPORTED);
+	ASSERT_TRUE((test.rel100_state_b & REL100_REQUIRE) == 0);
+	ASSERT_TRUE(test.sdp_state == EARLY_CONFIRMED);
 
 out:
 	test.a = mem_deref(test.a);
@@ -1155,6 +842,7 @@ int test_sipsess_100rel_answer_not_allowed(void)
 
 	test.rel100_a = REL100_ENABLED;
 	test.rel100_b = REL100_ENABLED;
+	test.conn_action = CONN_PROGR_ANS;
 
 	err = sip_alloc(&test.sip, NULL, 32, 32, 32,
 			"retest", exit_handler, NULL);
@@ -1169,8 +857,7 @@ int test_sipsess_100rel_answer_not_allowed(void)
 
 	port = sa_port(&laddr);
 
-	err = sipsess_listen(&test.sock, test.sip, 32,
-			     conn_handler_100rel_answer, &test);
+	err = sipsess_listen(&test.sock, test.sip, 32, conn_handler, &test);
 	TEST_ERR(err);
 
 	err = str_x64dup(&callid, rand_u64());
@@ -1192,13 +879,15 @@ int test_sipsess_100rel_answer_not_allowed(void)
 	err = re_main_timeout(200);
 	TEST_ERR(err);
 
-	TEST_ASSERT(test.err == -256);
+	TEST_ERR(test.progr_ret_code);
+	ASSERT_TRUE(test.err == 22);
+	ASSERT_TRUE(test.answ_ret_code == 22);
 
 	/* okay here -- verify */
-	TEST_ASSERT(!test.estab_a);
-	TEST_ASSERT(!test.estab_b);
-	TEST_ASSERT(test.sup_received_b);
-	TEST_ASSERT(!test.req_received_b);
+	ASSERT_TRUE(!test.estab_a);
+	ASSERT_TRUE(!test.estab_b);
+	ASSERT_TRUE(test.rel100_state_b & REL100_SUPPORTED);
+	ASSERT_TRUE((test.rel100_state_b & REL100_REQUIRE) == 0);
 
 out:
 	test.a = mem_deref(test.a);
@@ -1209,8 +898,6 @@ out:
 
 	sip_close(test.sip, false);
 	test.sip = mem_deref(test.sip);
-
-	mem_deref(test.desc);
 
 	return err;
 }
@@ -1229,6 +916,8 @@ int test_sipsess_100rel_420(void)
 
 	test.rel100_a = REL100_REQUIRED;
 	test.rel100_b = REL100_DISABLED;
+	test.conn_action = CONN_PROGRESS;
+	test.progr_ret_code = -1;
 
 	err = sip_alloc(&test.sip, NULL, 32, 32, 32,
 			"retest", exit_handler, NULL);
@@ -1243,7 +932,7 @@ int test_sipsess_100rel_420(void)
 
 	port = sa_port(&laddr);
 
-	err = sipsess_listen(&test.sock, test.sip, 32, conn_handler_420,
+	err = sipsess_listen(&test.sock, test.sip, 32, conn_handler,
 			     &test);
 	TEST_ERR(err);
 
@@ -1265,14 +954,15 @@ int test_sipsess_100rel_420(void)
 
 	err = re_main_timeout(200);
 	TEST_ERR(err);
+	ASSERT_TRUE(test.err == 22);
 
 	/* okay here -- verify */
-	TEST_ASSERT(!test.b);
-	TEST_ASSERT(!test.estab_a);
-	TEST_ASSERT(!test.estab_b);
-	TEST_ASSERT(test.desc);
+	ASSERT_TRUE(!test.b);
+	ASSERT_TRUE(!test.estab_a);
+	ASSERT_TRUE(!test.estab_b);
+	ASSERT_TRUE(test.desc);
 
- out:
+out:
 	test.a = mem_deref(test.a);
 	test.b = mem_deref(test.b);
 
@@ -1299,6 +989,8 @@ int test_sipsess_100rel_421(void)
 
 	test.rel100_a = REL100_DISABLED;
 	test.rel100_b = REL100_REQUIRED;
+	test.conn_action = CONN_PROGRESS;
+	test.progr_ret_code = -1;
 
 	err = sip_alloc(&test.sip, NULL, 32, 32, 32,
 			"retest", exit_handler, NULL);
@@ -1313,7 +1005,7 @@ int test_sipsess_100rel_421(void)
 
 	port = sa_port(&laddr);
 
-	err = sipsess_listen(&test.sock, test.sip, 32, conn_handler_420,
+	err = sipsess_listen(&test.sock, test.sip, 32, conn_handler,
 			     &test);
 	TEST_ERR(err);
 
@@ -1334,14 +1026,15 @@ int test_sipsess_100rel_421(void)
 
 	err = re_main_timeout(200);
 	TEST_ERR(err);
+	ASSERT_TRUE(test.err == 22);
 
 	/* okay here -- verify */
-	TEST_ASSERT(!test.b);
-	TEST_ASSERT(!test.estab_a);
-	TEST_ASSERT(!test.estab_b);
-	TEST_ASSERT(test.desc);
+	ASSERT_TRUE(!test.b);
+	ASSERT_TRUE(!test.estab_a);
+	ASSERT_TRUE(!test.estab_b);
+	ASSERT_TRUE(test.desc);
 
- out:
+out:
 	test.a = mem_deref(test.a);
 	test.b = mem_deref(test.b);
 
@@ -1369,6 +1062,8 @@ int test_sipsess_update_uac(void)
 
 	test.rel100_a = REL100_ENABLED;
 	test.rel100_b = REL100_ENABLED;
+	test.conn_action = CONN_PROGRESS;
+	test.prack_action = send_update_a;
 
 	err = sip_alloc(&test.sip, NULL, 32, 32, 32,
 			"retest", exit_handler, NULL);
@@ -1383,7 +1078,7 @@ int test_sipsess_update_uac(void)
 
 	port = sa_port(&laddr);
 
-	err = sipsess_listen(&test.sock, test.sip, 32, conn_handler_update,
+	err = sipsess_listen(&test.sock, test.sip, 32, conn_handler,
 			     &test);
 	TEST_ERR(err);
 
@@ -1396,7 +1091,7 @@ int test_sipsess_update_uac(void)
 			      "sip:a@127.0.0.1", "a", NULL, 0,
 			      "application/sdp", NULL, NULL, false,
 			      callid, desc_handler_a,
-			      offer_handler_update_a, answer_handler_a,
+			      offer_handler_a, answer_handler_a,
 			      progr_handler_a, estab_handler_a, NULL,
 			      NULL, close_handler, &test,
 			      "Supported: 100rel\r\n");
@@ -1412,17 +1107,17 @@ int test_sipsess_update_uac(void)
 	}
 
 	/* okay here -- verify */
-	TEST_ASSERT(test.estab_a);
-	TEST_ASSERT(test.estab_b);
-	TEST_ASSERT(test.answr_a);
-	TEST_ASSERT(!test.answr_b);
-	TEST_ASSERT(!test.offer_a);
-	TEST_ASSERT(test.offer_b);
-	TEST_ASSERT(test.progr_a);
-	TEST_ASSERT(test.upd_b);
-	TEST_ASSERT(!test.upd_a);
+	ASSERT_TRUE(test.estab_a);
+	ASSERT_TRUE(test.estab_b);
+	ASSERT_TRUE(test.answr_a);
+	ASSERT_TRUE(!test.answr_b);
+	ASSERT_TRUE(!test.offer_a);
+	ASSERT_TRUE(test.offer_b);
+	ASSERT_TRUE(test.progr_a);
+	ASSERT_TRUE(test.upd_b);
+	ASSERT_TRUE(!test.upd_a);
 
- out:
+out:
 	test.a = mem_deref(test.a);
 	test.b = mem_deref(test.b);
 
@@ -1453,6 +1148,8 @@ int test_sipsess_update_uas(void)
 
 	test.rel100_a = REL100_ENABLED;
 	test.rel100_b = REL100_ENABLED;
+	test.conn_action = CONN_PROGRESS;
+	test.prack_action = send_update_b;
 
 	err = sip_alloc(&test.sip, NULL, 32, 32, 32,
 			"retest", exit_handler, NULL);
@@ -1467,7 +1164,7 @@ int test_sipsess_update_uas(void)
 
 	port = sa_port(&laddr);
 
-	err = sipsess_listen(&test.sock, test.sip, 32, conn_handler_update_b,
+	err = sipsess_listen(&test.sock, test.sip, 32, conn_handler,
 			     &test);
 	TEST_ERR(err);
 
@@ -1480,7 +1177,7 @@ int test_sipsess_update_uas(void)
 			      "sip:a@127.0.0.1", "a", NULL, 0,
 			      "application/sdp", NULL, NULL, false,
 			      callid, desc_handler_a,
-			      offer_handler_update_a, answer_handler_a,
+			      offer_handler_a, answer_handler_a,
 			      progr_handler_a, estab_handler_a, NULL,
 			      NULL, close_handler, &test,
 			      "Supported: 100rel\r\n");
@@ -1496,17 +1193,17 @@ int test_sipsess_update_uas(void)
 	}
 
 	/* okay here -- verify */
-	TEST_ASSERT(test.estab_a);
-	TEST_ASSERT(test.estab_b);
-	TEST_ASSERT(test.answr_a);
-	TEST_ASSERT(test.answr_b);
-	TEST_ASSERT(test.offer_a);
-	TEST_ASSERT(test.offer_b);
-	TEST_ASSERT(test.progr_a);
-	TEST_ASSERT(test.upd_a);
-	TEST_ASSERT(!test.upd_b);
+	ASSERT_TRUE(test.estab_a);
+	ASSERT_TRUE(test.estab_b);
+	ASSERT_TRUE(test.answr_a);
+	ASSERT_TRUE(test.answr_b);
+	ASSERT_TRUE(test.offer_a);
+	ASSERT_TRUE(test.offer_b);
+	ASSERT_TRUE(test.progr_a);
+	ASSERT_TRUE(test.upd_a);
+	ASSERT_TRUE(!test.upd_b);
 
- out:
+out:
 	test.a = mem_deref(test.a);
 	test.b = mem_deref(test.b);
 

--- a/src/sipsess.c
+++ b/src/sipsess.c
@@ -34,7 +34,8 @@ enum rel100_state {
 enum connect_action {
 	CONN_PROGRESS = 1,
 	CONN_PROGR_ANS = 2,
-	CONN_ANSWER = 4
+	CONN_ANSWER = 4,
+	CONN_BUSY = 8
 };
 
 
@@ -114,14 +115,6 @@ static void exit_handler(void *arg)
 {
 	(void)arg;
 	re_cancel();
-}
-
-
-static void sess_abort_b(void *arg)
-{
-	struct test *test = arg;
-
-	sipsess_abort(test->b);
 }
 
 
@@ -372,6 +365,9 @@ static void close_handler(int err, const struct sip_msg *msg, void *arg)
 	struct test *test = arg;
 	(void)msg;
 
+	if (!err && test->conn_action == CONN_BUSY)
+		err = EBUSY;
+
 	abort_test(test, err ? err : ENOMEM);
 }
 
@@ -449,9 +445,25 @@ static void conn_handler(const struct sip_msg *msg, void *arg)
 			goto out;
 		}
 	}
+	else if (test->conn_action & CONN_BUSY) {
+		err = sipsess_accept(&test->b, test->sock, msg, 180,
+				"Ringing", test->rel100_b, "b",
+				"application/sdp", NULL, NULL, NULL, false,
+				offer_handler_b, answer_handler_b,
+				estab_handler_b, NULL, NULL, close_handler,
+				test, hdrs);
+		if (err != test->answ_ret_code) {
+			test->answ_ret_code = err;
+			goto out;
+		}
+		err |= sipsess_reject(test->b, 486, "Busy Here", NULL);
+		if (err != test->answ_ret_code) {
+			test->answ_ret_code = err;
+			goto out;
+		}
+	}
 
-	if (test->conn_action & CONN_ANSWER
-	    || test->conn_action & CONN_PROGR_ANS)
+	if (test->conn_action & (CONN_ANSWER | CONN_PROGR_ANS | CONN_BUSY))
 		mem_deref(desc);
 
 	return;
@@ -564,6 +576,77 @@ int test_sipsess(void)
 	ASSERT_TRUE(!test.offer_b);
 
  out:
+	test.a = mem_deref(test.a);
+	test.b = mem_deref(test.b);
+
+	sipsess_close_all(test.sock);
+	test.sock = mem_deref(test.sock);
+
+	sip_close(test.sip, false);
+	test.sip = mem_deref(test.sip);
+
+	return err;
+}
+
+
+int test_sipsess_reject(void)
+{
+	struct test test;
+	struct sa laddr;
+	char to_uri[256];
+	int err;
+	uint16_t port;
+	char *callid;
+
+	memset(&test, 0, sizeof(test));
+
+	test.rel100_a = REL100_DISABLED;
+	test.rel100_b = REL100_DISABLED;
+	test.conn_action = CONN_BUSY;
+
+	err = sip_alloc(&test.sip, NULL, 32, 32, 32,
+			"retest", exit_handler, NULL);
+	TEST_ERR(err);
+
+	(void)sa_set_str(&laddr, "127.0.0.1", 0);
+	err = sip_transp_add(test.sip, SIP_TRANSP_UDP, &laddr);
+	TEST_ERR(err);
+
+	err = sip_transp_laddr(test.sip, &laddr, SIP_TRANSP_UDP, NULL);
+	TEST_ERR(err);
+
+	port = sa_port(&laddr);
+
+	err = sipsess_listen(&test.sock, test.sip, 32, conn_handler, &test);
+	TEST_ERR(err);
+
+	err = str_x64dup(&callid, rand_u64());
+	TEST_ERR(err);
+
+	/* Connect to "b" */
+	(void)re_snprintf(to_uri, sizeof(to_uri), "sip:b@127.0.0.1:%u", port);
+	err = sipsess_connect(&test.a, test.sock, to_uri, NULL,
+			      "sip:a@127.0.0.1", "a", NULL, 0,
+			      "application/sdp", NULL, NULL, false,
+			      callid, desc_handler,
+			      offer_handler_a, answer_handler_a, NULL,
+			      estab_handler_a, NULL, NULL,
+			      close_handler, &test, NULL);
+	mem_deref(callid);
+	TEST_ERR(err);
+
+	err = re_main_timeout(200);
+	TEST_ERR(err);
+
+	/* okay here -- verify */
+	ASSERT_TRUE(test.err == EBUSY);
+	ASSERT_TRUE(!test.estab_a);
+	ASSERT_TRUE(!test.estab_b);
+	ASSERT_TRUE(test.desc);
+	ASSERT_TRUE(!test.answr_a);
+	ASSERT_TRUE(!test.offer_b);
+
+out:
 	test.a = mem_deref(test.a);
 	test.b = mem_deref(test.b);
 
@@ -825,89 +908,6 @@ out:
 	tmr_cancel(&test.ans_tmr);
 	test.a = mem_deref(test.a);
 	test.b = mem_deref(test.b);
-
-	sipsess_close_all(test.sock);
-	test.sock = mem_deref(test.sock);
-
-	sip_close(test.sip, false);
-	test.sip = mem_deref(test.sip);
-
-	mem_deref(test.desc);
-
-	return err;
-}
-
-
-int test_sipsess_100rel_abort(void)
-{
-	struct test test;
-	struct sa laddr;
-	char to_uri[256];
-	int err;
-	uint16_t port;
-	char *callid;
-
-	memset(&test, 0, sizeof(test));
-
-	test.rel100_a = REL100_ENABLED;
-	test.rel100_b = REL100_ENABLED;
-	test.conn_action = CONN_PROGRESS;
-	test.prack_action = sess_abort_b;
-
-	err = sip_alloc(&test.sip, NULL, 32, 32, 32,
-			"retest", exit_handler, NULL);
-	TEST_ERR(err);
-
-	(void)sa_set_str(&laddr, "127.0.0.1", 0);
-	err = sip_transp_add(test.sip, SIP_TRANSP_UDP, &laddr);
-	TEST_ERR(err);
-
-	err = sip_transp_laddr(test.sip, &laddr, SIP_TRANSP_UDP, NULL);
-	TEST_ERR(err);
-
-	port = sa_port(&laddr);
-
-	err = sipsess_listen(&test.sock, test.sip, 32, conn_handler,
-			     &test);
-	TEST_ERR(err);
-
-	err = str_x64dup(&callid, rand_u64());
-	TEST_ERR(err);
-
-	/* Connect to "b" */
-	(void)re_snprintf(to_uri, sizeof(to_uri), "sip:b@127.0.0.1:%u", port);
-	err = sipsess_connect(&test.a, test.sock, to_uri, NULL,
-			      "sip:a@127.0.0.1", "a", NULL, 0,
-			      "application/sdp", NULL, NULL, false,
-			      callid, desc_handler_a,
-			      offer_handler_a, answer_handler_a,
-			      progr_handler_a, estab_handler_a, NULL,
-			      NULL, close_handler, &test,
-			      "Supported: 100rel\r\n");
-	mem_deref(callid);
-	TEST_ERR(err);
-
-	err = re_main_timeout(200);
-	TEST_ERR(err);
-
-	ASSERT_TRUE(test.err == 104);
-
-	/* okay here -- verify */
-	ASSERT_TRUE(!test.estab_a);
-	ASSERT_TRUE(!test.estab_b);
-	ASSERT_TRUE(test.desc);
-	ASSERT_TRUE(test.answr_a);
-	ASSERT_TRUE(!test.offer_a);
-	ASSERT_TRUE(test.offer_b);
-	ASSERT_TRUE(!test.answr_b);
-	ASSERT_TRUE(test.progr_a);
-	ASSERT_TRUE(test.rel100_state_b & REL100_SUPPORTED);
-	ASSERT_TRUE((test.rel100_state_b & REL100_REQUIRE) == 0);
-	ASSERT_TRUE(test.sdp_state == EARLY_CONFIRMED);
-
-out:
-	tmr_cancel(&test.ans_tmr);
-	test.a = mem_deref(test.a);
 
 	sipsess_close_all(test.sock);
 	test.sock = mem_deref(test.sock);

--- a/src/test.c
+++ b/src/test.c
@@ -178,10 +178,10 @@ static const struct test tests[] = {
 #endif
 	TEST(test_sipevent),
 	TEST(test_sipsess),
+	TEST(test_sipsess_reject),
 	TEST(test_sipsess_blind_transfer),
 	TEST(test_sipsess_100rel_caller_require),
 	TEST(test_sipsess_100rel_supported),
-	TEST(test_sipsess_100rel_abort),
 	TEST(test_sipsess_100rel_answer_not_allowed),
 	TEST(test_sipsess_100rel_420),
 	TEST(test_sipsess_100rel_421),

--- a/src/test.c
+++ b/src/test.c
@@ -181,6 +181,7 @@ static const struct test tests[] = {
 	TEST(test_sipsess_blind_transfer),
 	TEST(test_sipsess_100rel_caller_require),
 	TEST(test_sipsess_100rel_supported),
+	TEST(test_sipsess_100rel_abort),
 	TEST(test_sipsess_100rel_answer_not_allowed),
 	TEST(test_sipsess_100rel_420),
 	TEST(test_sipsess_100rel_421),

--- a/src/test.c
+++ b/src/test.c
@@ -181,6 +181,7 @@ static const struct test tests[] = {
 	TEST(test_sipsess_blind_transfer),
 	TEST(test_sipsess_100rel_caller_require),
 	TEST(test_sipsess_100rel_supported),
+	TEST(test_sipsess_100rel_answer_not_allowed),
 	TEST(test_sipsess_100rel_420),
 	TEST(test_sipsess_100rel_421),
 	TEST(test_sipsess_update_uac),

--- a/src/test.h
+++ b/src/test.h
@@ -297,10 +297,10 @@ int test_sipreg_tcp(void);
 int test_sipreg_tls(void);
 #endif
 int test_sipsess(void);
+int test_sipsess_reject(void);
 int test_sipsess_blind_transfer(void);
 int test_sipsess_100rel_caller_require(void);
 int test_sipsess_100rel_supported(void);
-int test_sipsess_100rel_abort(void);
 int test_sipsess_100rel_answer_not_allowed(void);
 int test_sipsess_100rel_420(void);
 int test_sipsess_100rel_421(void);

--- a/src/test.h
+++ b/src/test.h
@@ -300,6 +300,7 @@ int test_sipsess(void);
 int test_sipsess_blind_transfer(void);
 int test_sipsess_100rel_caller_require(void);
 int test_sipsess_100rel_supported(void);
+int test_sipsess_100rel_answer_not_allowed(void);
 int test_sipsess_100rel_420(void);
 int test_sipsess_100rel_421(void);
 int test_sipsess_update_uac(void);

--- a/src/test.h
+++ b/src/test.h
@@ -300,6 +300,7 @@ int test_sipsess(void);
 int test_sipsess_blind_transfer(void);
 int test_sipsess_100rel_caller_require(void);
 int test_sipsess_100rel_supported(void);
+int test_sipsess_100rel_abort(void);
 int test_sipsess_100rel_answer_not_allowed(void);
 int test_sipsess_100rel_420(void);
 int test_sipsess_100rel_421(void);


### PR DESCRIPTION
Refactoring of PRACK related tests to only call `re_cancel()` once per test and remove code duplication.